### PR TITLE
Added first Impelmentation of the health checks

### DIFF
--- a/src/RavenNest/Health/GameServerHealthCheck.cs
+++ b/src/RavenNest/Health/GameServerHealthCheck.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using RavenNest.BusinessLogic;
+using RavenNest.BusinessLogic.Data;
+
+namespace RavenNest.Health
+{
+    public class GameServerHealthCheck : IHealthCheck
+    {
+        private readonly IKernel kernel;
+        private readonly IGameData gameData;
+
+        public GameServerHealthCheck(IKernel kernel, IGameData gameData)
+        {
+            this.kernel = kernel;
+            this.gameData = gameData;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+        {
+            if (kernel.Started)
+                return Task.FromResult(HealthCheckResult.Healthy());
+
+            return Task.FromResult(HealthCheckResult.Unhealthy("Kernel not started"));
+        }
+    }
+}

--- a/src/RavenNest/Health/GameServerHealthCheck.cs
+++ b/src/RavenNest/Health/GameServerHealthCheck.cs
@@ -9,12 +9,10 @@ namespace RavenNest.Health
     public class GameServerHealthCheck : IHealthCheck
     {
         private readonly IKernel kernel;
-        private readonly IGameData gameData;
 
-        public GameServerHealthCheck(IKernel kernel, IGameData gameData)
+        public GameServerHealthCheck(IKernel kernel)
         {
             this.kernel = kernel;
-            this.gameData = gameData;
         }
 
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())

--- a/src/RavenNest/Health/HealthCheckDependencyInjectionExtensions.cs
+++ b/src/RavenNest/Health/HealthCheckDependencyInjectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -18,7 +19,7 @@ namespace RavenNest.Health
         {
             var settings = configuration.Get<AppSettings>();
             services.AddHealthChecks()
-                    .AddSqlServer(settings.DbConnectionString)
+                    .AddSqlServer(settings.DbConnectionString, name: "SqlServer")
                     .AddCheck<GameServerHealthCheck>(nameof(GameServerHealthCheck));
             
             return services;
@@ -40,13 +41,13 @@ namespace RavenNest.Health
             var responseObj = new HealthResponse
             {
                 Status = result.Status.ToString(),
-                Results = result.Entries.Select(e => new HealthResult
-                                                {
-                                                    Status = e.Value.Status.ToString(),
-                                                    Description = e.Value.Description,
-                                                    Data = e.Value.Data
-                                                })
-                                        .ToList()
+                Results = result.Entries.ToDictionary(e => e.Key, e => 
+                    new HealthResult
+                    {
+                        Status = e.Value.Status.ToString(),
+                        Description = e.Value.Description,
+                        Data = e.Value.Data
+                    })
             };
 
             var response = JsonConvert.SerializeObject(responseObj, Formatting.Indented);

--- a/src/RavenNest/Health/HealthCheckDependencyInjectionExtensions.cs
+++ b/src/RavenNest/Health/HealthCheckDependencyInjectionExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using RavenNest.BusinessLogic;
+
+namespace RavenNest.Health
+{
+    public static class HealthCheckDependencyInjectionExtensions
+    {
+        public static IServiceCollection AddRavenNestHealthChecks(this IServiceCollection services, IConfiguration configuration)
+        {
+            var settings = configuration.Get<AppSettings>();
+            services.AddHealthChecks()
+                    .AddSqlServer(settings.DbConnectionString)
+                    .AddCheck<GameServerHealthCheck>(nameof(GameServerHealthCheck));
+            
+            return services;
+        }
+
+        public static IEndpointRouteBuilder MapRavenNestHealthChecks(this IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapHealthChecks("/health", new HealthCheckOptions()
+            {
+                ResponseWriter = WriteResponse
+            });
+            return endpoints;
+        }
+
+        private static Task WriteResponse(HttpContext context, HealthReport result)
+        {
+            context.Response.ContentType = "application/json; charset=utf-8";
+
+            var responseObj = new HealthResponse
+            {
+                Status = result.Status.ToString(),
+                Results = result.Entries.Select(e => new HealthResult
+                                                {
+                                                    Status = e.Value.Status.ToString(),
+                                                    Description = e.Value.Description,
+                                                    Data = e.Value.Data
+                                                })
+                                        .ToList()
+            };
+
+            var response = JsonConvert.SerializeObject(responseObj, Formatting.Indented);
+            return context.Response.WriteAsync(response);
+        }
+    }
+}

--- a/src/RavenNest/Health/HealthResponse.cs
+++ b/src/RavenNest/Health/HealthResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace RavenNest.Health
+{
+    public class HealthResponse
+    {
+        public string Status { get; set; }
+
+        public IList<HealthResult> Results { get; set; }
+    }
+}

--- a/src/RavenNest/Health/HealthResponse.cs
+++ b/src/RavenNest/Health/HealthResponse.cs
@@ -5,7 +5,6 @@ namespace RavenNest.Health
     public class HealthResponse
     {
         public string Status { get; set; }
-
-        public IList<HealthResult> Results { get; set; }
+        public IDictionary<string, HealthResult> Results { get; set; }
     }
 }

--- a/src/RavenNest/Health/HealthResult.cs
+++ b/src/RavenNest/Health/HealthResult.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace RavenNest.Health
+{
+    public class HealthResult
+    {
+        public string Status { get; set; }
+        public string Description { get; set; }
+        public IReadOnlyDictionary<string, object> Data { get; set; }
+    }
+}

--- a/src/RavenNest/RavenNest.csproj
+++ b/src/RavenNest/RavenNest.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.0-beta1" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="3.1.0-preview2.19528.8" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.1.0-preview2.19528.8" />
@@ -20,6 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.0-preview2.19528.8" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.1.0-preview2.19528.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0-preview2.19525.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />    
     <PackageReference Include="System.Data.SqlClient" Version="4.8.0-preview2.19523.17" />    

--- a/src/RavenNest/Startup.cs
+++ b/src/RavenNest/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
@@ -20,6 +21,7 @@ using RavenNest.BusinessLogic.Docs.Html;
 using RavenNest.BusinessLogic.Game;
 using RavenNest.BusinessLogic.Net;
 using RavenNest.BusinessLogic.Serializers;
+using RavenNest.Health;
 using RavenNest.Sessions;
 
 namespace RavenNest
@@ -82,6 +84,8 @@ namespace RavenNest
             {
                 options.Providers.Add<GzipCompressionProvider>();
             });
+
+            services.AddRavenNestHealthChecks(Configuration.GetSection("AppSettings"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -175,6 +179,7 @@ namespace RavenNest
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapRavenNestHealthChecks();
                 endpoints.MapControllers();
                 //endpoints.MapControllerRoute(
                 //    name: "default",


### PR DESCRIPTION
The endpoint https://localhost:{port}/health

will answer with such a json:
```json
{
  "Status": "Unhealthy",
  "Results": {
    "SqlServer": {
      "Status": "Healthy",
      "Description": null,
      "Data": {}
    },
    "GameServerHealthCheck": {
      "Status": "Unhealthy",
      "Description": "Kernel not started",
      "Data": {}
    }
  }
}
```